### PR TITLE
Fix EHLO parsing for address-literals

### DIFF
--- a/smtp.scm
+++ b/smtp.scm
@@ -468,14 +468,22 @@
 
 (define address-literal
   (abnf:concatenation
-   (abnf:char #\[) 
+   (abnf:drop-consumed (abnf:char #\[))
    (abnf:alternatives
     IPv4-address-literal 
     IPv6-address-literal 
     General-address-literal)
-   (abnf:char #\])))
+   (abnf:drop-consumed (abnf:char #\]))))
 
 ;; See Section 4.1.3
+
+(define domain-or-address-literal
+  (abnf:alternatives
+   domain
+   (abnf:bind-consumed-strings->list
+    (lambda (l)
+      (string-concatenate (intersperse l ".")))
+    address-literal)))
 
 (define Mailbox-p
   (abnf:bind
@@ -701,7 +709,7 @@
         (quit (mkcmdp0 "QUIT" Quit))
         (turn (mkcmdp0 "TURN" Turn))
         (helo (mkcmdp1 "HELO" Helo     domain))
-        (ehlo (mkcmdp1 "EHLO" Ehlo     domain))
+        (ehlo (mkcmdp1 "EHLO" Ehlo     domain-or-address-literal))
         (vrfy (mkcmdp1 "VRFY" Vrfy     Arg-string))
         (expn (mkcmdp1 "EXPN" Expn     Arg-string))
         

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -16,29 +16,45 @@
     "QUIT\r\n"
     ))
 
+(define ehlo-with-ipv4-address
+  `(
+    "EHLO [127.0.0.1]\r\n"
+    "QUIT\r\n"
+    ))
 
-(test-group "chicken-mta"
-	    
-(let ((output (open-output-string)))
-  (main
-   (open-input-string (string-concatenate rfc-D.1))
-   output)
+(test-group
+ "chicken-mta"
 
-  (test "rfc-D.1"
-   (string-append 
-    "250-chicken-mta\r\n"
-    "250- \r\n"
-    "250-Hello \r\n"
-    "250 bar.com\r\n"
-    "250 OK\r\n"
-    "250 Accepted\r\n"
-    "250 Accepted\r\n"
-    "250 Accepted\r\n"
-    "354 Ready\r\n"
-    "250 OK\r\n"
-    "251-chicken-mta\r\n"
-    "251  closing connection\r\n")
-   (get-output-string output))
-  ))
+ (test
+  "rfc-D.1"
+  (string-append
+   "250-chicken-mta\r\n"
+   "250- \r\n"
+   "250-Hello \r\n"
+   "250 bar.com\r\n"
+   "250 OK\r\n"
+   "250 Accepted\r\n"
+   "250 Accepted\r\n"
+   "250 Accepted\r\n"
+   "354 Ready\r\n"
+   "250 OK\r\n"
+   "251-chicken-mta\r\n"
+   "251  closing connection\r\n")
+  (let ((output (open-output-string)))
+    (main (open-input-string (string-concatenate rfc-D.1)) output)
+    (get-output-string output)))
+
+ (test
+  "ehlo with ipv4 address"
+  (string-append
+   "250-chicken-mta\r\n"
+   "250- \r\n"
+   "250-Hello \r\n"
+   "250 127.0.0.1\r\n"
+   "251-chicken-mta\r\n"
+   "251  closing connection\r\n")
+  (let ((output (open-output-string)))
+    (main (open-input-string (string-concatenate ehlo-with-ipv4-address)) output)
+    (get-output-string output))))
 
 (test-exit)


### PR DESCRIPTION
When testing against an smtp client, I found that the library does not parse EHLO messages that use an address-literal rather than domain, which is valid according to RFC 5321 (see the syntax definition in section 4.1.1.1).

Attached is a patch to parse EHLO messages that use an address-literal as well as a test that verifies this.